### PR TITLE
Free saveto buffers on exit

### DIFF
--- a/fdrd.c
+++ b/fdrd.c
@@ -553,6 +553,9 @@ saveto(struct instance *insp, struct item *itp)
 				perror(itp->target);
 			}
 	}
+	free(buf);
+	close(wfd);
+	close(rfd);
 }
 
 


### PR DESCRIPTION
Fixes #1

## Summary
Free the buffer allocated in `saveto()` before returning, and close the local file descriptors on the function exit path.

## Root Cause
`saveto()` allocated memory with `malloc()` and never released it when the loop ended.

## Validation
- `make clean && make`
