### PR TITLE
Close config files after parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Flight Data Recorder
-
+ 
 ## Description
 
 The flight data recorder (fdr) is a daemon which enables ftrace probes,

--- a/fdrd.c
+++ b/fdrd.c
@@ -590,6 +590,7 @@ read_config_file(const char *fpath, const struct stat *sb, int typeflag)
 	insp = malloc(sizeof(struct instance));
 	if (insp == NULL) {
 		perror("malloc");
+		fclose(f);
 		return 1;
 	}
 	insque(insp, &anchor);
@@ -714,6 +715,7 @@ read_config_file(const char *fpath, const struct stat *sb, int typeflag)
 			insp->ilast = itp;
 		}
 	}
+	fclose(f);
 	return 0;
 }
 


### PR DESCRIPTION
Fixes #2

## Summary
Close the config file stream after parsing completes, and also close it on the early allocation-failure path.

## Root Cause
`read_config_file()` opened the config file with `fopen()` and returned without calling `fclose()`.

## Validation
- `make clean && make`